### PR TITLE
Fixed too frequent widget refreshes.

### DIFF
--- a/mobile/src/main/java/com/LineaMeteoPremium/LineaMeteoPremium.java
+++ b/mobile/src/main/java/com/LineaMeteoPremium/LineaMeteoPremium.java
@@ -49,12 +49,12 @@ public class LineaMeteoPremium extends AppWidgetProvider {
         prefs = context.getSharedPreferences(
                 "com.LineaMeteoPremium", Context.MODE_PRIVATE);
 
+        RemoteViews remoteViews = new RemoteViews(context.getPackageName(), R.layout.linea_meteo_premium);
+        
         for (int widgetId : appWidgetIds) {
 
 
             setUpAlarm(context, widgetId);
-
-            RemoteViews remoteViews = new RemoteViews(context.getPackageName(), R.layout.linea_meteo_premium);
 
             Log.e("LineaMeteo Widget", "src " + src);
 
@@ -85,9 +85,6 @@ public class LineaMeteoPremium extends AppWidgetProvider {
                     .apply(options)
                     .into(awt);
         }
-
-
-
     }
 
     @Override
@@ -120,7 +117,7 @@ public class LineaMeteoPremium extends AppWidgetProvider {
      */
     private void setUpAlarm(Context context, int appWidgetId) {
         final AlarmManager alarm = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        long interval = (3 * 60000); // 60000 = 1minute  | Change the formula based on your refresh timing needs
+        long interval = (30 * 60000); // 60000 = 1minute  | TODO Change the formula based on your refresh timing needs
 
         PendingIntent alarmPendingIntent = getRefreshWidgetPendingIntent(context, appWidgetId);
 


### PR DESCRIPTION
Fixed incorrect widget refresh timings. The refresh timing previously used was 3 minutes. Which means widget requested refresh every 3 minutes which is too frequent which might cause problems and even lead to android OS possibly stop your app widget from refreshing due to excessive battery usage.